### PR TITLE
Added source aliases for cbsnl.json

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -87,5 +87,15 @@
 	"atldpcd:GLOBALID": "atldpcd:GLOBALID",
 	"stpaulgov:district": "stpaulgov:district",
 	"stpaulgov:name2": "stpaulgov:name2",
-	"stpaulgov:name1": "stpaulgov:name1"
+	"stpaulgov:name1": "stpaulgov:name1",
+	"cbsnl:WK_CODE": "cbsnl:WK_CODE",
+	"cbsnl:WK_NAAM": "cbsnl:WK_NAAM",
+	"cbsnl:GM_CODE": "cbsnl:GM_CODE",
+	"cbsnl:GM_NAAM": "cbsnl:GM_NAAM",
+	"cbsnl:IND_WBI": "cbsnl:IND_WBI",
+	"cbsnl:WATER": "cbsnl:WATER",
+	"cbsnl:OAD": "cbsnl:OAD",
+	"cbsnl:STED": "cbsnl:STED",
+	"cbsnl:BU_CODE": "cbsnl:BU_CODE",
+	"cbsnl:BU_NAAM": "cbsnl:BU_NAAM"
 }


### PR DESCRIPTION
In conjunction with [#44](https://github.com/whosonfirst/whosonfirst-sources/pull/44)

Added "cbsnl" aliases for use with the "Centraal Bureau voor de Statistiek (Netherlands)" source data.