### PR TITLE
Added source aliases for vanpds.json

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -132,6 +132,8 @@
 	"uscensus_m": "uscensus:mtfcc",
 	"uscensus_n": "uscensus:namelsad",
 	"uscensus_s": "uscensus:statefp",
+	"vanpds:MAPID": "vanpds:MAPID",
+	"vanpds:NAME": "vanpds:NAME",
 	"wapo:subhood": "wapo:subhood",
 	"wapo:quadrant": "wapo:quadrant",
 	"zolk:Name": "zolk:Name",


### PR DESCRIPTION
Added source aliases for the Vancouver Planning and Development Services.

[#49](https://github.com/whosonfirst/whosonfirst-sources/pull/49)