### PR TITLE
Added aliases for canvec-hydro.json

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -55,6 +55,8 @@
 	"can-mntsmvt:nom_mun": "can-mntsmvt:nom_mun",
 	"can-nwds:NEIGHNUM": "can-nwds:NEIGHNUM",
 	"can-nwds:NEIGH_NAME": "can-nwds:NEIGH_NAME",
+	"canvec-hydro:definit": "canvec-hydro:definit",
+	"canvec-hydro:definit_en": "canvec-hydro:definit_en",
 	"cbsnl:WK_CODE": "cbsnl:WK_CODE",
 	"cbsnl:WK_NAAM": "cbsnl:WK_NAAM",
 	"cbsnl:GM_CODE": "cbsnl:GM_CODE",


### PR DESCRIPTION
Added source aliases for Canvec hydrological data provided by Natural Resources Canada.

[Source file](https://github.com/whosonfirst/whosonfirst-sources/pull/61)
