### PR TITLE
Added aliases for Winnipeg neighbourhood data

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -62,6 +62,8 @@
 	"can-mntsmvt:nom_mun": "can-mntsmvt:nom_mun",
 	"can-nwds:NEIGHNUM": "can-nwds:NEIGHNUM",
 	"can-nwds:NEIGH_NAME": "can-nwds:NEIGH_NAME",
+	"can-wpgppd:name": "can-wpgppd:name",
+	"can-wpgppd:id": "can-wpgppd:id",
 	"canvec-hydro:definit": "canvec-hydro:definit",
 	"canvec-hydro:definit_en": "canvec-hydro:definit_en",
 	"cbsnl:WK_CODE": "cbsnl:WK_CODE",


### PR DESCRIPTION
Added source aliases for neighbourhood data provided by the City of Winnipeg Department of Planning, Property, and Development.

[Source](https://github.com/whosonfirst/whosonfirst-sources/pull/68)