### PR TITLE
Added aliases for Edmonton neighbourhood data

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -55,6 +55,8 @@
 	"can-dnvgov:MET_TECH": "can-dnvgov:MET_TECH",
 	"can-dnvgov:MET_TECH_R": "can-dnvgov:MET_TECH_R",
 	"can-dnvgov:GLOBALID": "can-dnvgov:GLOBALID",
+	"can-edmdsd:name": "can-edmdsd:name",
+	"can-edmdsd:number": "can-edmdsd:number",
 	"can-mntsmvt:no_qr": "can-mntsmvt:no_qr",
 	"can-mntsmvt:nom_qr": "can-mntsmvt:nom_qr",
 	"can-mntsmvt:no_arr": "can-mntsmvt:no_arr",


### PR DESCRIPTION
Added source aliases for neighbourhood data provided by the City of Edmonton Department of Sustainable Development.

[Source](https://github.com/whosonfirst/whosonfirst-sources/pull/69)