### PR TITLE
mz:is_funky json and README updates

### DIFF
--- a/properties/mz/README.md
+++ b/properties/mz/README.md
@@ -54,7 +54,7 @@ Therefore, any record with a date in the `edtf:cessation` or `edtf:deprecated` f
 * `0` is false
 * `1` is true
 
-Records with a `1` value are recommended to be hidden from map display and search unless explicitly asked for by name.
+Used when Mapzen suspects the record is bad or inappropriate but additional confirmation is needed before the feature is deprecated. Records with a `1` value are recommended to be hidden from map display and search unless explicitly asked for by name.
 
 ## is_hard_boundary
 

--- a/properties/mz/README.md
+++ b/properties/mz/README.md
@@ -54,6 +54,8 @@ Therefore, any record with a date in the `edtf:cessation` or `edtf:deprecated` f
 * `0` is false
 * `1` is true
 
+Records with a `1` value are recommended to be hidden from map display and search unless explicitly asked for by name.
+
 ## is_hard_boundary
 
 Things like historic districts or similar with fixed, undisputed boundaries.

--- a/properties/mz/is_funky.json
+++ b/properties/mz/is_funky.json
@@ -2,6 +2,6 @@
     "id": 1158807917,
     "name": "is_funky",
     "prefix": "mz",
-    "description": "Signifies whether or not a given record may need additional updates and whether or not a record is filtered out of Mapzen services unless explicitly asked for.",
+    "description": "Used when Mapzen suspects the record is bad or inappropriate but additional confirmation is needed before the feature is deprecated. Records with a 1 value are recommended to be hidden from map display and search unless explicitly asked for by name.",
     "type": "integer"
 }

--- a/properties/mz/is_funky.json
+++ b/properties/mz/is_funky.json
@@ -2,6 +2,6 @@
     "id": 1158807917,
     "name": "is_funky",
     "prefix": "mz",
-    "description": "Signifies whether or not a given record may need additional updates.",
+    "description": "Signifies whether or not a given record may need additional updates and whether or not a record is filtered out of Mapzen services unless explicitly asked for.",
     "type": "integer"
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst/whosonfirst-properties/issues/41.

Adds a note to the `mz` README about `mz:is_funky = 1` cases and updates the description in the `is_funky.json` file.