### PR TITLE
mz:remarks property description

### DIFF
--- a/properties/mz/README.md
+++ b/properties/mz/README.md
@@ -89,6 +89,15 @@ Float values (though in practice mosts are integer values) that match to web map
 
 A string value used for notes when hand-curating a given record.
 
+## remarks
+
+The name of the markdown file containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.",
+
+#### Example
+```
+data/115/885/753/1/1158857531-remarks.md
+```
+
 ## tier_locality
 
 Some estimation of coverage (including descendants) and completeness, based on total number of geotagged photos.

--- a/properties/mz/README.md
+++ b/properties/mz/README.md
@@ -91,11 +91,14 @@ A string value used for notes when hand-curating a given record.
 
 ## remarks
 
-The name of the markdown file containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.",
+The name of the markdown file(s) containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.
 
 #### Example
+
 ```
-data/115/885/753/1/1158857531-remarks.md
+"mz:remarks:[
+  "1158857531-remarks.md"
+]
 ```
 
 ## tier_locality

--- a/properties/mz/remarks.json
+++ b/properties/mz/remarks.json
@@ -2,6 +2,6 @@
     "id": 1158859079,
     "name": "remarks",
     "prefix": "mz",
-    "description": "The of the markdown file containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.",
-    "type": "string"
+    "description": "The name of the markdown file(s) containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.",
+    "type": "list"
 }

--- a/properties/mz/remarks.json
+++ b/properties/mz/remarks.json
@@ -1,0 +1,7 @@
+{
+    "id": 1158859079,
+    "name": "remarks",
+    "prefix": "mz",
+    "description": "The of the markdown file containing human-readable notes for a given record. The file is stored in the same folder and contains edit notes about that record.",
+    "type": "string"
+}


### PR DESCRIPTION
Fixes #55. New description for `"mz:remarks"` property and updated `README.md` file.