### PR TITLE
Added source aliases for London neighbourhood data

### DIFF
--- a/aliases/source_data_aliases.json
+++ b/aliases/source_data_aliases.json
@@ -113,6 +113,8 @@
 	"esp-cartobcn:N_Barri": "esp-cartobcn:N_Barri",
 	"esp-cartobcn:WEB_1": "esp-cartobcn:WEB_1",
 	"esp-cartobcn:WEB_4": "esp-cartobcn:WEB_4",
+	"gbr-datalondon:GSS_CODE": "gbr-datalondon:GSS_CODE",
+	"gbr-datalondon:ONS_INNER": "gbr-datalondon:ONS_INNER",
 	"hkigis:kokotunnus": "hkigis:kokotunnus",
 	"hkigis:aluejako": "hkigis:aluejako",
 	"hkigis:tunnus": "hkigis:tunnus",


### PR DESCRIPTION
Added aliases for source data provided by the Greater London Authority.

[Source](https://github.com/whosonfirst/whosonfirst-sources/pull/94)