### PR TITLE
Fix Case-sensitive Property File Names

### DIFF
--- a/properties/amsgis/CODE.json
+++ b/properties/amsgis/CODE.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079619, 
-  "name": "CODE", 
-  "prefix": "amsgis", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/amsgis/NAAM.json
+++ b/properties/amsgis/NAAM.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079609, 
-  "name": "NAAM", 
-  "prefix": "amsgis", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/cbsnl/gm_code.json
+++ b/properties/cbsnl/gm_code.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079907, 
-  "name": "gm_code", 
-  "prefix": "cbsnl", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/figov/aluejako.json
+++ b/properties/figov/aluejako.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079997, 
-  "name": "aluejako", 
-  "prefix": "figov", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/fsgov/aluejako.json
+++ b/properties/fsgov/aluejako.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079995, 
-  "name": "aluejako", 
-  "prefix": "fsgov", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/hkigis/Nimi.json
+++ b/properties/hkigis/Nimi.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079871, 
-  "name": "Nimi", 
-  "prefix": "hkigis", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/hkigis/kokotunnus.json
+++ b/properties/hkigis/kokotunnus.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079863, 
-  "name": "kokotunnus", 
-  "prefix": "hkigis", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/hkigis/tunnus.json
+++ b/properties/hkigis/tunnus.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079865, 
-  "name": "tunnus", 
-  "prefix": "hkigis", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/adm0_a3.json
+++ b/properties/ne/adm0_a3.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079397, 
-  "name": "ADM0_A3", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/adm0cap.json
+++ b/properties/ne/adm0cap.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079399, 
-  "name": "ADM0CAP", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/adm0name.json
+++ b/properties/ne/adm0name.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079437, 
-  "name": "ADM0NAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/adm1name.json
+++ b/properties/ne/adm1name.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079377, 
-  "name": "ADM1NAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/admin1_cod.json
+++ b/properties/ne/admin1_cod.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079341, 
-  "name": "ADMIN1_COD", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/capalt.json
+++ b/properties/ne/capalt.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079375, 
-  "name": "CAPALT", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/capin.json
+++ b/properties/ne/capin.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079347, 
-  "name": "CAPIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/changed.json
+++ b/properties/ne/changed.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079345, 
-  "name": "CHANGED", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/checkme.json
+++ b/properties/ne/checkme.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079415, 
-  "name": "CHECKME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/cityalt.json
+++ b/properties/ne/cityalt.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079317, 
-  "name": "CITYALT", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/compare.json
+++ b/properties/ne/compare.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079271, 
-  "name": "COMPARE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/diffascii.json
+++ b/properties/ne/diffascii.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079279, 
-  "name": "DIFFASCII", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/diffnote.json
+++ b/properties/ne/diffnote.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079291, 
-  "name": "DIFFNOTE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/elevation.json
+++ b/properties/ne/elevation.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079303, 
-  "name": "ELEVATION", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/feature_cl.json
+++ b/properties/ne/feature_cl.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079449, 
-  "name": "FEATURE_CL", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/feature_co.json
+++ b/properties/ne/feature_co.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079353, 
-  "name": "FEATURE_CO", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/featurecla.json
+++ b/properties/ne/featurecla.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079299, 
-  "name": "FEATURECLA", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/geonameid.json
+++ b/properties/ne/geonameid.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079275, 
-  "name": "GEONAMEID", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/geonamesno.json
+++ b/properties/ne/geonamesno.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079273, 
-  "name": "GEONAMESNO", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/gn_ascii.json
+++ b/properties/ne/gn_ascii.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079467, 
-  "name": "GN_ASCII", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/gn_pop.json
+++ b/properties/ne/gn_pop.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079281, 
-  "name": "GN_POP", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/gtopo30.json
+++ b/properties/ne/gtopo30.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079379, 
-  "name": "GTOPO30", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/iso_a2.json
+++ b/properties/ne/iso_a2.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079287, 
-  "name": "ISO_A2", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/labelrank.json
+++ b/properties/ne/labelrank.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079357, 
-  "name": "LABELRANK", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/latitude.json
+++ b/properties/ne/latitude.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079451, 
-  "name": "LATITUDE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/longitude.json
+++ b/properties/ne/longitude.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079365, 
-  "name": "LONGITUDE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/ls_match.json
+++ b/properties/ne/ls_match.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079439, 
-  "name": "LS_MATCH", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/ls_name.json
+++ b/properties/ne/ls_name.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079441, 
-  "name": "LS_NAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_areakm.json
+++ b/properties/ne/max_areakm.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079351, 
-  "name": "MAX_AREAKM", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_areami.json
+++ b/properties/ne/max_areami.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079321, 
-  "name": "MAX_AREAMI", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_bbxmax.json
+++ b/properties/ne/max_bbxmax.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079329, 
-  "name": "MAX_BBXMAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_bbxmin.json
+++ b/properties/ne/max_bbxmin.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079465, 
-  "name": "MAX_BBXMIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_bbymax.json
+++ b/properties/ne/max_bbymax.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079269, 
-  "name": "MAX_BBYMAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_bbymin.json
+++ b/properties/ne/max_bbymin.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079339, 
-  "name": "MAX_BBYMIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_natsca.json
+++ b/properties/ne/max_natsca.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079359, 
-  "name": "MAX_NATSCA", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_perkm.json
+++ b/properties/ne/max_perkm.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079313, 
-  "name": "MAX_PERKM", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_permi.json
+++ b/properties/ne/max_permi.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079297, 
-  "name": "MAX_PERMI", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_pop10.json
+++ b/properties/ne/max_pop10.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079385, 
-  "name": "MAX_POP10", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_pop20.json
+++ b/properties/ne/max_pop20.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079393, 
-  "name": "MAX_POP20", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_pop300.json
+++ b/properties/ne/max_pop300.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079429, 
-  "name": "MAX_POP300", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_pop310.json
+++ b/properties/ne/max_pop310.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079323, 
-  "name": "MAX_POP310", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/max_pop50.json
+++ b/properties/ne/max_pop50.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079289, 
-  "name": "MAX_POP50", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/mean_bbxc.json
+++ b/properties/ne/mean_bbxc.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079401, 
-  "name": "MEAN_BBXC", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/mean_bbyc.json
+++ b/properties/ne/mean_bbyc.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079453, 
-  "name": "MEAN_BBYC", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/megacity.json
+++ b/properties/ne/megacity.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079263, 
-  "name": "MEGACITY", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/meganame.json
+++ b/properties/ne/meganame.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079405, 
-  "name": "MEGANAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_areakm.json
+++ b/properties/ne/min_areakm.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079413, 
-  "name": "MIN_AREAKM", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_areami.json
+++ b/properties/ne/min_areami.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079305, 
-  "name": "MIN_AREAMI", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_bbxmax.json
+++ b/properties/ne/min_bbxmax.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079457, 
-  "name": "MIN_BBXMAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_bbxmin.json
+++ b/properties/ne/min_bbxmin.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079387, 
-  "name": "MIN_BBXMIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_bbymax.json
+++ b/properties/ne/min_bbymax.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079423, 
-  "name": "MIN_BBYMAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_bbymin.json
+++ b/properties/ne/min_bbymin.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079331, 
-  "name": "MIN_BBYMIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_perkm.json
+++ b/properties/ne/min_perkm.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079367, 
-  "name": "MIN_PERKM", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/min_permi.json
+++ b/properties/ne/min_permi.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079417, 
-  "name": "MIN_PERMI", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/name.json
+++ b/properties/ne/name.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079333, 
-  "name": "NAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/namealt.json
+++ b/properties/ne/namealt.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079309, 
-  "name": "NAMEALT", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/nameascii.json
+++ b/properties/ne/nameascii.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079455, 
-  "name": "NAMEASCII", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/namediff.json
+++ b/properties/ne/namediff.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079307, 
-  "name": "NAMEDIFF", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/namepar.json
+++ b/properties/ne/namepar.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079419, 
-  "name": "NAMEPAR", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/natscale.json
+++ b/properties/ne/natscale.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079295, 
-  "name": "NATSCALE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/note.json
+++ b/properties/ne/note.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079389, 
-  "name": "NOTE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1950.json
+++ b/properties/ne/pop1950.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079371, 
-  "name": "POP1950", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1955.json
+++ b/properties/ne/pop1955.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079469, 
-  "name": "POP1955", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1960.json
+++ b/properties/ne/pop1960.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079425, 
-  "name": "POP1960", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1965.json
+++ b/properties/ne/pop1965.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079459, 
-  "name": "POP1965", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1970.json
+++ b/properties/ne/pop1970.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079335, 
-  "name": "POP1970", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1975.json
+++ b/properties/ne/pop1975.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079395, 
-  "name": "POP1975", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1980.json
+++ b/properties/ne/pop1980.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079407, 
-  "name": "POP1980", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1985.json
+++ b/properties/ne/pop1985.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079381, 
-  "name": "POP1985", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1990.json
+++ b/properties/ne/pop1990.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079431, 
-  "name": "POP1990", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop1995.json
+++ b/properties/ne/pop1995.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079343, 
-  "name": "POP1995", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2000.json
+++ b/properties/ne/pop2000.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079369, 
-  "name": "POP2000", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2005.json
+++ b/properties/ne/pop2005.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079403, 
-  "name": "POP2005", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2010.json
+++ b/properties/ne/pop2010.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079433, 
-  "name": "POP2010", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2015.json
+++ b/properties/ne/pop2015.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079325, 
-  "name": "POP2015", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2020.json
+++ b/properties/ne/pop2020.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079411, 
-  "name": "POP2020", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2025.json
+++ b/properties/ne/pop2025.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079277, 
-  "name": "POP2025", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop2050.json
+++ b/properties/ne/pop2050.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079293, 
-  "name": "POP2050", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop_max.json
+++ b/properties/ne/pop_max.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079383, 
-  "name": "POP_MAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop_min.json
+++ b/properties/ne/pop_min.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079461, 
-  "name": "POP_MIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/pop_other.json
+++ b/properties/ne/pop_other.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079447, 
-  "name": "POP_OTHER", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/rank_max.json
+++ b/properties/ne/rank_max.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079285, 
-  "name": "RANK_MAX", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/rank_min.json
+++ b/properties/ne/rank_min.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079267, 
-  "name": "RANK_MIN", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/scalerank.json
+++ b/properties/ne/scalerank.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079421, 
-  "name": "SCALERANK", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/sov0name.json
+++ b/properties/ne/sov0name.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079361, 
-  "name": "SOV0NAME", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/sov_a3.json
+++ b/properties/ne/sov_a3.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079327, 
-  "name": "SOV_A3", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/timezone.json
+++ b/properties/ne/timezone.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079363, 
-  "name": "TIMEZONE", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/un_adm0.json
+++ b/properties/ne/un_adm0.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079311, 
-  "name": "UN_ADM0", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/un_fid.json
+++ b/properties/ne/un_fid.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079349, 
-  "name": "UN_FID", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/un_lat.json
+++ b/properties/ne/un_lat.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079443, 
-  "name": "UN_LAT", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/un_long.json
+++ b/properties/ne/un_long.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079435, 
-  "name": "UN_LONG", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}

--- a/properties/ne/worldcity.json
+++ b/properties/ne/worldcity.json
@@ -1,7 +1,0 @@
-{
-  "id": 1159079315, 
-  "name": "WORLDCITY", 
-  "prefix": "ne", 
-  "description": "", 
-  "type": ""
-}


### PR DESCRIPTION
In the `amsgis`, `cbsnl`, `figov`, `fsgov` and `hkigis` property definitions, some files exist in various uppercase, lowercase and camelcase combinations, which cause problems on case-insensitive file systems.

For each filename clash, one file has been removed, depending on the original case of the property name from the original source data.

This is a cut down version of PR #64 and supersedes that PR.