### PR TITLE
Update misc properties

### DIFF
--- a/properties/misc/README.md
+++ b/properties/misc/README.md
@@ -1,3 +1,3 @@
 # misc
 
-`misc` is a property prefix placeholder, used as a fallback prefix when Who's On First [export tools](https://github.com/whosonfirst/py-mapzen-whosonfirst-export) can not find an existing property prefix.
+`misc` is a property prefix placeholder, used as a fallback prefix when Who's On First [export tools](https://github.com/whosonfirst/py-mapzen-whosonfirst-export) can not determine or find an existing property prefix.

--- a/properties/misc/README.md
+++ b/properties/misc/README.md
@@ -1,0 +1,3 @@
+# misc
+
+`misc` is a property prefix placeholder, used as a fallback prefix when Who's On First [export tools](https://github.com/whosonfirst/py-mapzen-whosonfirst-export) can not find an existing property prefix.

--- a/properties/misc/gn_adm0_cc.json
+++ b/properties/misc/gn_adm0_cc.json
@@ -2,6 +2,7 @@
   "id": 1159079511, 
   "name": "gn_adm0_cc", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/gn_fcode.json
+++ b/properties/misc/gn_fcode.json
@@ -2,6 +2,7 @@
   "id": 1159079521, 
   "name": "gn_fcode", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/gn_id.json
+++ b/properties/misc/gn_id.json
@@ -3,5 +3,6 @@
   "name": "gn_id",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/gn_local.json
+++ b/properties/misc/gn_local.json
@@ -3,5 +3,6 @@
   "name": "gn_local",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/gn_nam_loc.json
+++ b/properties/misc/gn_nam_loc.json
@@ -3,5 +3,6 @@
   "name": "gn_nam_loc",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/gn_namadm1.json
+++ b/properties/misc/gn_namadm1.json
@@ -2,6 +2,7 @@
   "id": 1159079487, 
   "name": "gn_namadm1", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/gn_name.json
+++ b/properties/misc/gn_name.json
@@ -2,6 +2,7 @@
   "id": 1159079475, 
   "name": "gn_name", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/local_max.json
+++ b/properties/misc/local_max.json
@@ -3,5 +3,6 @@
   "name": "local_max",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/local_sum.json
+++ b/properties/misc/local_sum.json
@@ -3,5 +3,6 @@
   "name": "local_sum",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/localhoods.json
+++ b/properties/misc/localhoods.json
@@ -3,5 +3,6 @@
   "name": "localhoods",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/name.json
+++ b/properties/misc/name.json
@@ -2,6 +2,7 @@
   "id": 1159079471, 
   "name": "name", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_adm0.json
+++ b/properties/misc/name_adm0.json
@@ -2,6 +2,7 @@
   "id": 1159079483, 
   "name": "name_adm0", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_adm1.json
+++ b/properties/misc/name_adm1.json
@@ -2,6 +2,7 @@
   "id": 1159079503, 
   "name": "name_adm1", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_adm2.json
+++ b/properties/misc/name_adm2.json
@@ -2,6 +2,7 @@
   "id": 1159079505, 
   "name": "name_adm2", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_en.json
+++ b/properties/misc/name_en.json
@@ -2,6 +2,7 @@
   "id": 1159079531, 
   "name": "name_en", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_lau.json
+++ b/properties/misc/name_lau.json
@@ -2,6 +2,7 @@
   "id": 1159079527, 
   "name": "name_lau", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/name_local.json
+++ b/properties/misc/name_local.json
@@ -2,6 +2,7 @@
   "id": 1159079519, 
   "name": "name_local", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/photo_max.json
+++ b/properties/misc/photo_max.json
@@ -3,5 +3,6 @@
   "name": "photo_max",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/photo_sum.json
+++ b/properties/misc/photo_sum.json
@@ -3,5 +3,6 @@
   "name": "photo_sum",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/placetype.json
+++ b/properties/misc/placetype.json
@@ -2,6 +2,7 @@
   "id": 1159079515, 
   "name": "placetype", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_a0.json
+++ b/properties/misc/qs_a0.json
@@ -2,6 +2,7 @@
   "id": 1159079961, 
   "name": "qs_a0", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_a0_lc.json
+++ b/properties/misc/qs_a0_lc.json
@@ -3,6 +3,7 @@
   "name": "qs_a0_lc",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_a1.json
+++ b/properties/misc/qs_a1.json
@@ -2,6 +2,7 @@
   "id": 1159079959, 
   "name": "qs_a1", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_a1_alt.json
+++ b/properties/misc/qs_a1_alt.json
@@ -3,6 +3,7 @@
   "name": "qs_a1_alt",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_a1_lc.json
+++ b/properties/misc/qs_a1_lc.json
@@ -3,6 +3,7 @@
   "name": "qs_a1_lc",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_a1r.json
+++ b/properties/misc/qs_a1r.json
@@ -3,6 +3,7 @@
   "name": "qs_a1r",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_a1r_alt.json
+++ b/properties/misc/qs_a1r_alt.json
@@ -3,6 +3,7 @@
   "name": "qs_a1r_alt",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_a1r_lc.json
+++ b/properties/misc/qs_a1r_lc.json
@@ -3,6 +3,7 @@
   "name": "qs_a1r_lc",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_adm0.json
+++ b/properties/misc/qs_adm0.json
@@ -2,6 +2,7 @@
   "id": 1159079925, 
   "name": "qs_adm0", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_adm0_a3.json
+++ b/properties/misc/qs_adm0_a3.json
@@ -2,6 +2,7 @@
   "id": 1159079939, 
   "name": "qs_adm0_a3", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_gn_id.json
+++ b/properties/misc/qs_gn_id.json
@@ -3,6 +3,7 @@
   "name": "qs_gn_id",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_id.json
+++ b/properties/misc/qs_id.json
@@ -3,6 +3,7 @@
   "name": "qs_id",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_iso_cc.json
+++ b/properties/misc/qs_iso_cc.json
@@ -2,6 +2,7 @@
   "id": 1159079955, 
   "name": "qs_iso_cc", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_level.json
+++ b/properties/misc/qs_level.json
@@ -2,6 +2,7 @@
   "id": 1159079951, 
   "name": "qs_level", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_pop.json
+++ b/properties/misc/qs_pop.json
@@ -3,6 +3,7 @@
   "name": "qs_pop",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_scale.json
+++ b/properties/misc/qs_scale.json
@@ -3,6 +3,7 @@
   "name": "qs_scale",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/qs_source.json
+++ b/properties/misc/qs_source.json
@@ -2,6 +2,7 @@
   "id": 1159079957, 
   "name": "qs_source", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_type.json
+++ b/properties/misc/qs_type.json
@@ -2,6 +2,7 @@
   "id": 1159079933, 
   "name": "qs_type", 
   "prefix": "misc", 
-  "description": "", 
+  "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/qs_woe_id.json
+++ b/properties/misc/qs_woe_id.json
@@ -3,6 +3,7 @@
   "name": "qs_woe_id",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": [
       "string",
       "null"

--- a/properties/misc/quad_count.json
+++ b/properties/misc/quad_count.json
@@ -3,5 +3,6 @@
   "name": "quad_count",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_adm0.json
+++ b/properties/misc/woe_adm0.json
@@ -3,5 +3,6 @@
   "name": "woe_adm0",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_adm1.json
+++ b/properties/misc/woe_adm1.json
@@ -3,5 +3,6 @@
   "name": "woe_adm1",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_adm2.json
+++ b/properties/misc/woe_adm2.json
@@ -3,5 +3,6 @@
   "name": "woe_adm2",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_funk.json
+++ b/properties/misc/woe_funk.json
@@ -3,5 +3,6 @@
   "name": "woe_funk",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/woe_lau.json
+++ b/properties/misc/woe_lau.json
@@ -3,5 +3,6 @@
   "name": "woe_lau",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_local.json
+++ b/properties/misc/woe_local.json
@@ -3,5 +3,6 @@
   "name": "woe_local",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }

--- a/properties/misc/woe_ver.json
+++ b/properties/misc/woe_ver.json
@@ -3,5 +3,6 @@
   "name": "woe_ver",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "string"
 }

--- a/properties/misc/woeid.json
+++ b/properties/misc/woeid.json
@@ -3,5 +3,6 @@
   "name": "woeid",
   "prefix": "misc",
   "description": "",
+  "edtf:deprecated": "2018-06-28",
   "type": "integer"
 }


### PR DESCRIPTION
Fixes #72.

Deprecated existing `misc:` properties, added README to the misc directory.

Did not catalogue each of the `misc:` properties, but rather added a note about why/when the `misc:` prefix is used.