### PR TITLE
Updates/add properties that had multiple separators

### DIFF
--- a/properties/meso/README.md
+++ b/properties/meso/README.md
@@ -193,3 +193,6 @@
 ## type_loc
 
 ## type_local
+
+## wof_id
+A Mesoshapes-derived value of a Who's On First `wof:id` property value. This `wof:id` represents the identifier of a 'matched' Who's On First record that was found during importing of the Mesoshapes data.

--- a/properties/meso/wof_id.json
+++ b/properties/meso/wof_id.json
@@ -1,0 +1,7 @@
+{
+    "id": 1495037875,
+    "name": "wof_id",
+    "prefix": "meso",
+    "description": "A Mesoshapes-derived value of a Who's On First `wof:id` property value. This `wof:id` represents the identifier of a 'matched' Who's On First record that was found during importing of the Mesoshapes data.",
+    "type": "string"
+}

--- a/properties/src/README.md
+++ b/properties/src/README.md
@@ -18,14 +18,19 @@ For example, if a source geometry needs to be simplified using Mapshaper, "whoso
 _Example: `"src:geom_via":"os"`_
 
 ## lbl
-The source of a record's `lbl` properties. Valid property values are generally derived from [`mapshaper`](https://github.com/mbloch/mapshaper) and is also listed in the [`whosonfirst-sources`](https://github.com/whosonfirst/whosonfirst-sources/tree/master/sources) repository.
+The source of a record's `lbl` properties. Valid property values are generally hand-curated, but are sometimes derived from [`Mapshaper`](https://github.com/mbloch/mapshaper). Some sources are listed in the [`whosonfirst-sources`](https://github.com/whosonfirst/whosonfirst-sources/tree/master/sources) repository.
 
-Other iterations of the `lbl` property can include `lbl:centroid` and `centroid_lbl`; these properties are specific to the label centroid of a given feature.
+Other iterations of the `lbl` property can include `lbl_centroid` and `centroid_lbl`; these properties are specific to the label centroid of a given feature.
 
-_Example: `"src:lbl":"mapshaper"` or `"src:lbl:centroid":"mapshaper"`_
+_Example: `"src:lbl":"mapshaper"` and `"src:lbl_centroid_":"whosonfirst"`_
 
 ## population
 The source of a record's population value, which is stored in the wof:population property. Property values are a source name.
 
 _Example: `"src:population":"statoids"`_
+
+## population_date
+The date representing when a record's population value was catalogued. Property values follow the _YYYY-MM-DD_ format.
+
+_Example: `"src:population_date":"2010-04-01"`_
 

--- a/properties/src/population_date.json
+++ b/properties/src/population_date.json
@@ -2,6 +2,6 @@
     "id": 1495044599,
     "name": "population_date",
     "prefix": "src",
-    "description": "The date representing when a record's population value was catalogued.",
+    "description": "The date representing when a record's population value was catalogued. Property value is typically formatted in an EDTF format, like `YYYY-MM-DD` or `YYYY`.",
     "type": "string"
 }

--- a/properties/src/population_date.json
+++ b/properties/src/population_date.json
@@ -1,0 +1,7 @@
+{
+    "id": 1495044599,
+    "name": "population_date",
+    "prefix": "src",
+    "description": "The date representing when a record's population value was catalogued.",
+    "type": "string"
+}

--- a/properties/statoids/README.md
+++ b/properties/statoids/README.md
@@ -78,6 +78,10 @@ In English, using characters in the Latin-1 character set. Other characters, suc
 
 Most recent census figures available. Where no census is available, most recent estimates available. When subdivisions split, often shows a cross-reference to the other fragment.
 
+## population_date
+
+A value derived from Statoids that signifies the date at which the population value was gathered. The value follows the _YYYY-MM-DD_ format.
+
 ## statoid
 
 Level-3 hierarchical administrative subdivision code, defined by Statoids, used as a primary key for this table.

--- a/properties/statoids/population_date.json
+++ b/properties/statoids/population_date.json
@@ -1,0 +1,7 @@
+{
+    "id": 1495037873,
+    "name": "population_date",
+    "prefix": "statoids",
+    "description": "A value derived from Statoids that signifies the date at which the population value was gathered. The value follows the YYYY-MM-DD format.",
+    "type": "string"
+}


### PR DESCRIPTION
Fixes https://github.com/whosonfirst/whosonfirst-properties/issues/87

- Adds `meso:wof_id` property description and updates the `meso` README
- Adds `src:population_date` property description and updates the `src` README
- Adds `statoids:population_date` property description and updates the `statoids` README

Property descriptions for the older format of these properties(like `meso:wof:id`) were missing, so this PR simply adds the new property json files and updates README files as needed.