### PR TITLE
Updated README and json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,10 @@
 *~
+*.bz2
+.commit
+Makefile.*
+.gitignore.*
+.DS_Store
+.changed-*
+.merge-*
+bin
+*.svg

--- a/properties/wof/README.md
+++ b/properties/wof/README.md
@@ -69,6 +69,10 @@ An auto-generated, non-editable Unix epoch timestamp integer.
 
 A property used for timezone records. The value is a more robust version of the wof:name and includes the country or continent name that the timezone geometry falls within.
 
+## geom_alt
+
+A list of each of the record's alt-geometry files' filenames, minus the '{ID}-alt' prefix and '.geojson' suffix. Each alt-geometry file's '{SOURCE}-{FUNCTION}-{EXTRAS}' will be listed.
+
 ## geomhash
 
 An auto-generated, non-editable MD5 string of the geometry JSON.

--- a/properties/wof/README.md
+++ b/properties/wof/README.md
@@ -79,7 +79,7 @@ A list of hashes, where each object is the list of ancestors.
 
 ## id
 
-The record's unique numeric integer identifier that are typically derived from [Brooklyn Integers](https://www.brooklynintegers.com).
+The record's unique numeric integer identifier, typically derived from [Brooklyn Integers](https://www.brooklynintegers.com).
 
 ## label
 

--- a/properties/wof/geom_alt.json
+++ b/properties/wof/geom_alt.json
@@ -1,0 +1,7 @@
+{
+    "id": 1712374175,
+    "name": "geom_alt",
+    "prefix": "wof",
+    "description": "A list of each of the record's alt-geometry files' filenames, minus the '{ID}-alt' prefix and '.geojson' suffix. Each alt-geometry file's '{SOURCE}-{FUNCTION}-{EXTRAS}' will be listed.",
+    "type": "list"
+}

--- a/properties/wof/id.json
+++ b/properties/wof/id.json
@@ -2,6 +2,6 @@
     "id": 1158807957,
     "name": "id",
     "prefix": "wof",
-    "description": "The record's unique numeric integer identifier that are typically derived from Brooklyn Integers.",
+    "description": "The record's unique numeric integer identifier, typically derived from Brooklyn Integers.",
     "type": "integer"
 }

--- a/properties/wof/population_rank.json
+++ b/properties/wof/population_rank.json
@@ -2,6 +2,6 @@
     "id": 1158807973,
     "name": "population_rank",
     "prefix": "wof",
-    "description": "An aggregated integer, 0 to 18, to represent the population value for a given record.",
+    "description": "An aggregated integer, 0 to 18, to represent the population value for a given record. This property also allows Who's On First to give an approximate range when an exact population value can't be set.",
     "type": "integer"
 }


### PR DESCRIPTION
Fixes https://github.com/whosonfirst/whosonfirst-properties/issues/91.
Fixes https://github.com/whosonfirst/whosonfirst-properties/issues/83.
Fixes https://github.com/whosonfirst/whosonfirst-properties/issues/92.

This PR includes:

- Updated `gitignore` file, identical to the per-country repo `gitignore` files
- Updated `wof:population_rank` json file. The README looks good as-is.
- New json and README description for `wof:geom_alt`
- A better description for `wof:id`