### PR TITLE
Update wof:repo descriptions

### DIFF
--- a/properties/wof/README.md
+++ b/properties/wof/README.md
@@ -180,6 +180,10 @@ A list of string [placetypes](https://github.com/whosonfirst/whosonfirst-placety
 
 What locals consider the placetype to be (string value).
 
+## repo
+
+A string label containing the full name of the parent repository housing the record.
+
 ## scale
 
 A weighted value to represent the size of a given record. The smaller the value, the larger the record's scale.

--- a/properties/wof/repo.json
+++ b/properties/wof/repo.json
@@ -2,7 +2,7 @@
   "id": 1159079109,
   "name": "repo",
   "prefix": "wof",
-  "description": "",
+  "description": "A string label containing the full name of the parent repository housing the record.",
   "type": "string",
   "patterns": {
       "value": "^whosonfirst-.*$"


### PR DESCRIPTION
As part of https://github.com/whosonfirst-data/whosonfirst-data/issues/1729#issuecomment-550174858, this PR adds `wof:repo` to the `wof/README.md` file and adds a property description to the JSON file.