### PR TITLE
Update capital_of prop

### DIFF
--- a/properties/wof/README.md
+++ b/properties/wof/README.md
@@ -28,7 +28,7 @@ A list property used to link country or dependency records to their administrati
 
 ## capital_of
 
-A list property used to link administrative, judicial, and/or legislative capitals to their parent administrative record. The values are equal to the `wof:id` of each parent administrative record. This property can be present on any placetype (including `region` and `county`), but is typically found on `country` and `dependency` records.
+A list property used to link administrative, judicial, and/or legislative capitals to their parent administrative record. The values are equal to the `wof:id` of the parent administrative record(s) it is capital of. This property can be present on any placetype (including `region` and `county`), but is typically found on `country` and `dependency` records.
 
 ## concordances
 

--- a/properties/wof/README.md
+++ b/properties/wof/README.md
@@ -28,7 +28,7 @@ A list property used to link country or dependency records to their administrati
 
 ## capital_of
 
-A string property used to link administrative, judicial, and/or legislative capitals to their parent country or dependency. The values are equal to the `wof:id` of the parent country or dependency.
+A list property used to link administrative, judicial, and/or legislative capitals to their parent administrative record. The values are equal to the `wof:id` of each parent administrative record. This property can be present on any placetype (including `region` and `county`), but is typically found on `country` and `dependency` records.
 
 ## concordances
 

--- a/properties/wof/capital_of.json
+++ b/properties/wof/capital_of.json
@@ -3,5 +3,8 @@
     "name": "capital_of",
     "prefix": "wof",
     "description": "A string property used to link administrative, judicial, and/or legislative capitals to their parent country or dependency. The values are equal to the wof:id of the parent country or dependency.",
-    "type": "string"
+    "type": "list",
+    "items": {
+        "type": "integer"
+    }
 }


### PR DESCRIPTION
This PR updates the property `type` for `wof:capital_of` from string to list. This is needed to better represent the relationships between capitals and countries/admin1 records in WOF.